### PR TITLE
Remove policy already in AmazonEKSWorkerNodePolicy

### DIFF
--- a/eks_node_group_role.tf
+++ b/eks_node_group_role.tf
@@ -18,6 +18,16 @@ data "aws_iam_policy_document" "eks_node_group_assume_role_policy" {
       identifiers = ["ec2.amazonaws.com"]
     }
   }
+  statement {
+    actions = [
+      "sts:AssumeRole",
+      "sts:TagSession"
+    ]
+    principals {
+      type        = "Service"
+      identifiers = ["pods.eks.amazonaws.com"]
+    }
+  }
 }
 resource "aws_iam_role_policy_attachment" "AmazonEKSWorkerNodePolicy" {
   count      = !var.use_fargate ? 1 : 0

--- a/eks_node_group_role.tf
+++ b/eks_node_group_role.tf
@@ -18,12 +18,6 @@ data "aws_iam_policy_document" "eks_node_group_assume_role_policy" {
       identifiers = ["ec2.amazonaws.com"]
     }
   }
-  statement {
-    actions = [
-      "eks-auth:AssumeRoleForPodIdentity"
-    ]
-    resources = ["*"]
-  }
 }
 resource "aws_iam_role_policy_attachment" "AmazonEKSWorkerNodePolicy" {
   count      = !var.use_fargate ? 1 : 0


### PR DESCRIPTION
I add a custom policy but we do not need it as it is by default in AmazonEKSWorkerNodePolicy and change the assume role